### PR TITLE
Set plural form of taxonomy name as its name and menu_name

### DIFF
--- a/features/custom-tax/custom-tax.php
+++ b/features/custom-tax/custom-tax.php
@@ -20,7 +20,7 @@ if ( current_theme_supports( 'custom-tax' ) ) {
 		foreach ( $taxonomies as $key => $tax ) {
 
 			$labels = array(
-				'name' => $tax['singular'],
+				'name' => $tax['plural'],
 				'singular_name' => $tax['singular'],
 				'search_items' => 'Search ' . $tax['plural'],
 				'all_items' => 'All ' . $tax['plural'],
@@ -28,7 +28,7 @@ if ( current_theme_supports( 'custom-tax' ) ) {
 				'update_item' => 'Update ' . $tax['singular'],
 				'add_new_item' => 'Add new ' . $tax['singular'],
 				'new_item_name' => 'New ' . $tax['singular'],
-				'menu_name' => isset( $tax['menu_name'] ) ? $tax['menu_name'] : $tax['singular'],
+				'menu_name' => isset( $tax['menu_name'] ) ? $tax['menu_name'] : $tax['plural'],
 				'parent_item' => 'Parent ' . $tax['singular'],
 				'parent_item_colon' => 'Parent ' . $tax['singular'],
 				'separate_items_with_commas' => 'Separate tags with commas ' . $tax['plural'],


### PR DESCRIPTION
WordPress uses plural form of taxonomy name as a label in WP Admin left menu and in header on taxonomy page (https://github.com/WordPress/WordPress/blob/master/wp-includes/taxonomy.php#L474):
![00000731](https://cloud.githubusercontent.com/assets/166641/4334137/e52dc0e0-3fe9-11e4-9bff-f4eaf1093d29.png)

I applied the same convention for `custom-tax` feature, as currently singular form of taxonomy name is used in those areas.
